### PR TITLE
Add lazy-loaded similar products block

### DIFF
--- a/backend/src/main/java/com/ainan/ecommforallbackend/core/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ainan/ecommforallbackend/core/config/SecurityConfig.java
@@ -80,7 +80,8 @@ public class SecurityConfig {
                                 "/api/brands/**",
                                 "/api/product-images/**",
                                 "/api/variant-images/**",
-                                "/api/variants/**")
+                                "/api/variants/**",
+                                "/api/ai/similar-products/**")
                         .permitAll()
                         // admin only endpoints
                         .requestMatchers("/api/users/**").hasRole("ADMIN")

--- a/frontend/src/domains/AI/api/similarProductsApi.ts
+++ b/frontend/src/domains/AI/api/similarProductsApi.ts
@@ -2,19 +2,15 @@ import { API } from "../../../config/api";
 import { similarProductsResponse } from "../types";
 
 export async function fetchSimilarProducts(
-    productId: string
+    productId: string,
+    limit: number = 5
 ): Promise<similarProductsResponse> {
-    const token = localStorage.getItem("authToken");
-    if (!token) {
-        throw new Error("Authentication required");
-    }
-
     const url = new URL(`${API.BASE_URL}/ai/similar-products/${productId}`);
+    url.searchParams.set("limit", String(limit));
     const response = await fetch(url.toString(), {
         method: "GET",
         headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
         },
     });
 

--- a/frontend/src/domains/AI/hooks/useSimilarProducts.ts
+++ b/frontend/src/domains/AI/hooks/useSimilarProducts.ts
@@ -1,10 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { fetchSimilarProducts } from "../api/similarProductsApi";
 
-export function useSimilarProducts(productId: string, enabled: boolean = true) {
+export function useSimilarProducts(
+    productId: string,
+    enabled: boolean = true,
+    limit: number = 5
+) {
     return useQuery({
-        queryKey: ["similarProducts", productId],
-        queryFn: () => fetchSimilarProducts(productId),
+        queryKey: ["similarProducts", productId, limit],
+        queryFn: () => fetchSimilarProducts(productId, limit),
         enabled: enabled && !!productId, // Only run query if productId exists and enabled is true
     });
 }


### PR DESCRIPTION
## Summary
- add a lazy-loaded Similar Products section on product pages capped at 5 items
- allow unauthenticated access to the similar-products endpoint and drop auth on the frontend request
- polish similar product cards with pointer cursor and click handling

## Testing
- UI test: Similar Products loads on product page (local dev server)
- docker compose build backend
- docker compose up -d backend